### PR TITLE
EVA-3488 - Remove requirement for assembly report / other refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,27 @@
 EVA Submission Command Line Interface for Validation
 
 
-
-
 ## Installation
 
 TBD
 
 ## Input files for the validation and submission tool
 
-### The VCF file and association with reference genome
+There are two ways of specifying the VCF files and associated assembly
+
+### Using  `--vcf_files` and `--assembly_fasta`
+
+This allows you to provide multiple VCF file to validate and a single genome file associated. 
+The VCF file and genome associated must use the same chromosome naming convention 
+
+### Using  `--vcf_files_mapping`
 
 The path to the VCF files are provided via CSV file that links the VCF to their respective fasta sequence. This allows 
 us to support different assemblies for each VCF file 
 The CSV file `vcf_mapping.csv` contains the following columns vcf, fasta, report providing respectively:
  - The VCF to validate/upload
  - The assembly in fasta format that was used to derive the VCF
- - The assembly report associated with the assembly (if available) as found in NCBI assemblies (https://www.ncbi.nlm.nih.gov/genome/doc/ftpfaq/#files)
-
+ - (Optional) The assembly report associated with the assembly (if available) as found in NCBI assemblies (https://www.ncbi.nlm.nih.gov/genome/doc/ftpfaq/#files)
 
 Example:
 ```shell
@@ -48,7 +52,7 @@ To validate and submit run the following command
 
 ```shell
 eva-sub-cli.py --metadata_xlsx metadata_spreadsheet.xlsx \
-               --vcf_files_mapping vcf_mapping.csv --submission_dir submission_dir
+               --vcf_files vcf_file1.vcf vcf_file2.vcf --assembly_fasta assembly.fa --submission_dir submission_dir
 ```
 
 ### Validate only

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ There are two ways of specifying the VCF files and associated assembly
 
 ### Using  `--vcf_files` and `--assembly_fasta`
 
-This allows you to provide multiple VCF file to validate and a single genome file associated. 
-The VCF file and genome associated must use the same chromosome naming convention 
+This allows you to provide multiple VCF files to validate and a single associated genome file.
+The VCF files and the associated genome file must use the same chromosome naming convention 
 
 ### Using  `--vcf_files_mapping`
 

--- a/bin/eva-sub-cli.py
+++ b/bin/eva-sub-cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-
+import os
+import sys
 from argparse import ArgumentParser
 
 from ebi_eva_common_pyutils.logger import logging_config
@@ -7,27 +8,56 @@ from ebi_eva_common_pyutils.logger import logging_config
 from eva_sub_cli import  main
 from eva_sub_cli.main import VALIDATE, SUBMIT
 
+def validate_command_line_arguments(args, argparser):
+
+    if args.vcf_files_mapping and (args.vcf_files or args.assembly_fasta):
+        print("Specify vcf_files and assembly_fasta OR a vcf_files_mapping in CSV. Not both")
+        argparser.print_usage()
+        sys.exit(1)
+
+    if (args.vcf_files and not args.assembly_fasta) or (not args.vcf_files and args.assembly_fasta):
+        print("When using --vcf_files and --assembly_fasta, both needs to be specified")
+        argparser.print_usage()
+        sys.exit(1)
+
+    if SUBMIT in args.tasks and (
+            not (args.username or os.environ.get('ENAWEBINACCOUNT')) or
+            not (args.password or os.environ.get('ENAWEBINPASSWORD'))):
+        print("To submit your data, you need to provide a Webin username and password")
+        argparser.print_usage()
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     argparser = ArgumentParser(description='EVA Submission CLI - validate and submit data to EVA')
+    argparser.add_argument('--submission_dir', required=True, type=str,
+                           help='Full path to the directory where all processing will be done '
+                                'and submission info is/will be stored')
+    vcf_group = argparser.add_argument_group(
+        'Input VCF and assembly',
+        "Specify the VCF files and associated assembly with the following options. If you used different assembly "
+        "for different VCF files then use --vcf_file_mapping"
+    )
+    vcf_group.add_argument('--vcf_files', nargs='+', help="One or several vcf file to validate")
+    vcf_group.add_argument('--assembly_fasta',
+                           help="The fasta file containing the reference genome from which the variant were derived")
+    vcf_group.add_argument("--vcf_files_mapping",
+                           help="csv file with the mappings for vcf files, fasta and assembly report")
+
+    metadata_group = argparser.add_argument_group('Metadata', 'Specify the metadata in a spreadsheet of in a JSON file')
+    metadata_group = metadata_group.add_mutually_exclusive_group(required=True)
+    metadata_group.add_argument("--metadata_json",
+                               help="Json file that describe the project, analysis, samples and files")
+    metadata_group.add_argument("--metadata_xlsx",
+                               help="Excel spreadsheet  that describe the project, analysis, samples and files")
     argparser.add_argument('--tasks', nargs='*', choices=[VALIDATE, SUBMIT], default=[SUBMIT],
                            help='Select a task to perform. Selecting VALIDATE will run the validation regardless of the outcome of '
                                 'previous runs. Selecting SUBMIT will run validate only if the validation was not performed '
                                 'successfully before and then run the submission.')
-    argparser.add_argument('--submission_dir', required=True, type=str,
-                           help='Full path to the directory where all processing will be done '
-                                'and submission info is/will be stored')
-    argparser.add_argument("--vcf_files_mapping", required=True,
-                           help="csv file with the mappings for vcf files, fasta and assembly report")
-    group = argparser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--metadata_json",
-                       help="Json file that describe the project, analysis, samples and files")
-    group.add_argument("--metadata_xlsx",
-                       help="Excel spreadsheet  that describe the project, analysis, samples and files")
-    argparser.add_argument("--username",
-                           help="Username used for connecting to the ENA webin account")
-    argparser.add_argument("--password",
-                           help="Password used for connecting to the ENA webin account")
+    credential_group = argparser.add_argument_group('Credential', 'Specify the Webin credential you want to use to '
+                                                                  'upload to the EVA')
+    credential_group.add_argument("--username", help="Username used for connecting to the ENA webin account")
+    credential_group.add_argument("--password", help="Password used for connecting to the ENA webin account")
     argparser.add_argument("--resume", default=False, action='store_true',
                            help="Resume the process execution from where it left of. This is currently only supported "
                                 "for the upload part of the SUBMIT task.")
@@ -36,5 +66,6 @@ if __name__ == "__main__":
 
     logging_config.add_stdout_handler()
 
-    main.orchestrate_process(args.submission_dir, args.vcf_files_mapping, args.metadata_json, args.metadata_xlsx,
-                             args.tasks, args.resume)
+    validate_command_line_arguments(args, argparser)
+    # Pass on all the arguments
+    main.orchestrate_process(**args.__dict__)

--- a/bin/eva-sub-cli.py
+++ b/bin/eva-sub-cli.py
@@ -16,7 +16,7 @@ def validate_command_line_arguments(args, argparser):
         sys.exit(1)
 
     if (args.vcf_files and not args.assembly_fasta) or (not args.vcf_files and args.assembly_fasta):
-        print("When using --vcf_files and --assembly_fasta, both needs to be specified")
+        print("When using --vcf_files and --assembly_fasta, both need to be specified")
         argparser.print_usage()
         sys.exit(1)
 
@@ -35,16 +35,16 @@ if __name__ == "__main__":
                                 'and submission info is/will be stored')
     vcf_group = argparser.add_argument_group(
         'Input VCF and assembly',
-        "Specify the VCF files and associated assembly with the following options. If you used different assembly "
+        "Specify the VCF files and associated assembly with the following options. If you used different assemblies "
         "for different VCF files then use --vcf_file_mapping"
     )
-    vcf_group.add_argument('--vcf_files', nargs='+', help="One or several vcf file to validate")
+    vcf_group.add_argument('--vcf_files', nargs='+', help="One or several vcf files to validate")
     vcf_group.add_argument('--assembly_fasta',
-                           help="The fasta file containing the reference genome from which the variant were derived")
+                           help="The fasta file containing the reference genome from which the variants were derived")
     vcf_group.add_argument("--vcf_files_mapping",
                            help="csv file with the mappings for vcf files, fasta and assembly report")
 
-    metadata_group = argparser.add_argument_group('Metadata', 'Specify the metadata in a spreadsheet of in a JSON file')
+    metadata_group = argparser.add_argument_group('Metadata', 'Specify the metadata in a spreadsheet or in a JSON file')
     metadata_group = metadata_group.add_mutually_exclusive_group(required=True)
     metadata_group.add_argument("--metadata_json",
                                help="Json file that describe the project, analysis, samples and files")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,6 @@ RUN curl -LJo /usr/local/bin/vcf_validator  https://github.com/EBIvariation/vcf-
 # Install biovalidator and make it executable
 RUN git clone https://github.com/elixir-europe/biovalidator.git  \
     && cd biovalidator  \
-    && chmod +x src/biovalidator.js \
-    && sed -i 's/dist/src/' package.json \
     && npm install \
     && npm link
 

--- a/tests/ignore_test_nextflow_validation.yml
+++ b/tests/ignore_test_nextflow_validation.yml
@@ -1,0 +1,6 @@
+- name: My pipeline
+  command: nextflow run eva_sub_cli/nextflow/validation.nf --base_dir /Users/tcezard/PycharmProjects/eva-sub-cli --vcf_files_mapping tests/resources/vcf_files.csv --output_dir tests/resources/validation_output/ --metadata_xlsx tests/resources/EVA_Submission_test.xlsx
+  files:
+    - path: "tests/resources/validation_output/assembly_check/input_passed.vcf.assembly_check.log"
+    - path: "tests/resources/validation_output/assembly_check/input_passed.vcf.text_assembly_report.*.txt"
+    - path: "tests/resources/validation_output/assembly_check/input_passed.vcf.assembly_check.log"


### PR DESCRIPTION
- Refactor validation nextflow to be able to run it without docker
- Remove the requirement for file that are part of eva-sub-cli
- Make assembly report optional
- Allow vcf files and assembly to be provided from the command line