### PR TITLE
EVA-3666 - Docker resilience

### DIFF
--- a/eva_sub_cli/validators/docker_validator.py
+++ b/eva_sub_cli/validators/docker_validator.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 
 from ebi_eva_common_pyutils.logger import logging_config
+from retry import retry
 
 from eva_sub_cli.validators.validator import Validator
 
@@ -166,6 +167,7 @@ class DockerValidator(Validator):
             )
             print(f'Verify that container is running after stop {self.verify_container_is_running()}')
 
+    @retry(RuntimeError, tries=3, delay=5, backoff=1, jitter=2, logger=logger)
     def download_container_image_if_needed(self):
         if not self.verify_image_available_locally():
             logger.debug(f"Pulling container ({container_image}) image")

--- a/tests/test_docker_validator.py
+++ b/tests/test_docker_validator.py
@@ -1,7 +1,9 @@
 import json
 import os
 import shutil
+import subprocess
 from unittest import TestCase
+from unittest.mock import patch
 
 import yaml
 
@@ -194,3 +196,13 @@ class TestDockerValidator(TestCase):
                                  'property': '/project/childProjects/0'}
         self.assess_post_validation(self.validator_from_excel, expected_sample_checker, expected_metadata_files_json,
                                     expected_metadata_val, expected_semantic_val)
+
+    def test_download_container_image_if_needed(self):
+        with patch('eva_sub_cli.validators.validator.run_command_with_output') as m_run_command:
+            m_run_command.side_effect = [
+                None,                                       # <- verify_image_available_locally
+                subprocess.CalledProcessError(1, 'pull'),   # <- First Pull
+                None,                                       # <- verify_image_available_locally
+                None                                        # <- Second Pull
+            ]
+            self.validator.download_container_image_if_needed()

--- a/tests/test_docker_validator.py
+++ b/tests/test_docker_validator.py
@@ -16,15 +16,16 @@ class TestDockerValidator(TestCase):
     fasta_files = os.path.join(resources_folder, 'fasta_files')
     assembly_reports = os.path.join(resources_folder, 'assembly_reports')
 
-    test_run_dir = os.path.join(resources_folder, 'docker_test_run')
-    mapping_file = os.path.join(test_run_dir, 'vcf_files_metadata.csv')
-    metadata_json = os.path.join(test_run_dir, 'sub_metadata.json')
-    metadata_xlsx = os.path.join(test_run_dir, 'sub_metadata.xlsx')
+    test_run_dir1 = os.path.join(resources_folder, 'docker_test_run1')
+    test_run_dir2 = os.path.join(resources_folder, 'docker_test_run2')
+    mapping_file = os.path.join(test_run_dir1, 'vcf_files_metadata.csv')
+    metadata_json = os.path.join(test_run_dir1, 'sub_metadata.json')
+    metadata_xlsx = os.path.join(test_run_dir2, 'sub_metadata.xlsx')
 
-    submission_dir = test_run_dir
 
     def setUp(self):
-        os.makedirs(self.test_run_dir, exist_ok=True)
+        os.makedirs(self.test_run_dir1, exist_ok=True)
+        os.makedirs(self.test_run_dir2, exist_ok=True)
 
         # create vcf mapping file
         create_mapping_file(self.mapping_file,
@@ -50,10 +51,9 @@ class TestDockerValidator(TestCase):
             json.dump(sub_metadata, open_metadata)
         self.validator = DockerValidator(
             mapping_file=self.mapping_file,
-            submission_dir=self.submission_dir,
+            submission_dir=self.test_run_dir1,
             project_title=self.project_title,
-            metadata_json=self.metadata_json,
-            container_name='eva-sub-cli-test'
+            metadata_json=self.metadata_json
         )
         shutil.copyfile(
             os.path.join(self.resources_folder, 'EVA_Submission_test.xlsx'),
@@ -62,28 +62,35 @@ class TestDockerValidator(TestCase):
 
         self.validator_from_excel = DockerValidator(
             mapping_file=self.mapping_file,
-            submission_dir=self.submission_dir,
+            submission_dir=self.test_run_dir2,
             project_title=self.project_title,
-            metadata_xlsx=self.metadata_xlsx,
-            container_name='eva-sub-cli-test'
+            metadata_xlsx=self.metadata_xlsx
         )
 
     def tearDown(self):
-        if os.path.exists(self.test_run_dir):
-            shutil.rmtree(self.test_run_dir)
+        for d in [self.test_run_dir1, self.test_run_dir2]:
+            if os.path.exists(d):
+                shutil.rmtree(d)
         self.validator.stop_running_container()
         self.validator_from_excel.stop_running_container()
+
+    def assert_same_dict_and_unordered_list(self, o1, o2):
+        if isinstance(o1, dict) and isinstance(o2, dict):
+            self.assertEqual(set(o1), set(o2))
+            [self.assert_same_dict_and_unordered_list(o1.get(k), o2.get(k)) for k in o1]
+        elif isinstance(o1, list) and isinstance(o2, list):
+            self.assertEqual(set(o1), set(o2))
+        else:
+            self.assertEqual(o1, o2)
 
     def assert_sample_checker(self, sample_checker_file, expected_checker):
         self.assertTrue(os.path.isfile(sample_checker_file))
         with open(sample_checker_file) as open_yaml:
-            assert yaml.safe_load(open_yaml) == expected_checker
+            self.assert_same_dict_and_unordered_list(yaml.safe_load(open_yaml), expected_checker)
 
-    def test_validate(self):
-        # run validation in docker
-        self.validator.validate()
-
-        vcf_format_dir = os.path.join(self.validator.output_dir, 'vcf_format')
+    def assess_post_validation(self, validator, expected_sample_checker, expected_metadata_files_json,
+                               expected_metadata_val, expected_semantic_val):
+        vcf_format_dir = os.path.join(validator.output_dir, 'vcf_format')
         self.assertTrue(os.path.exists(vcf_format_dir))
 
         vcf_format_log_file = os.path.join(vcf_format_dir, 'input_passed.vcf.vcf_format.log')
@@ -95,13 +102,13 @@ class TestDockerValidator(TestCase):
                              vcf_format_logs[3])
 
             text_report = vcf_format_logs[2].split(':')[1].strip()
-            with open(os.path.join(self.validator.output_dir, text_report)) as text_report:
+            with open(os.path.join(validator.output_dir, text_report)) as text_report:
                 text_report_content = text_report.readlines()
                 self.assertEqual('According to the VCF specification, the input file is valid\n',
                                  text_report_content[0])
 
         # assert assembly report
-        assembly_check_dir = os.path.join(self.validator.output_dir, 'assembly_check')
+        assembly_check_dir = os.path.join(validator.output_dir, 'assembly_check')
         self.assertTrue(os.path.exists(assembly_check_dir))
 
         assembly_check_log_file = os.path.join(assembly_check_dir, 'input_passed.vcf.assembly_check.log')
@@ -113,7 +120,28 @@ class TestDockerValidator(TestCase):
             self.assertEqual('[info] Percentage of matches: 100%\n', assembly_check_logs[5])
 
         # Assert Samples concordance
-        expected_checker = {
+        self.assert_sample_checker(validator._sample_check_yaml, expected_sample_checker)
+
+        with open(validator.metadata_json_post_validation) as open_file:
+            json_data = json.load(open_file)
+            assert json_data.get('files') == expected_metadata_files_json
+
+        # Check metadata errors
+        with open(os.path.join(validator.output_dir, 'other_validations', 'metadata_validation.txt')) as open_file:
+            metadata_val_lines = {l.strip() for l in open_file.readlines()}
+            assert any((expected_metadata_val in line for line in metadata_val_lines))
+
+        # Check semantic metadata errors
+        semantic_yaml_file = os.path.join(validator.output_dir, 'other_validations', 'metadata_semantic_check.yml')
+        self.assertTrue(os.path.isfile(semantic_yaml_file))
+        with open(semantic_yaml_file) as open_yaml:
+            semantic_output = yaml.safe_load(open_yaml)
+            assert semantic_output[1] == expected_semantic_val
+
+    def test_validate(self):
+        # run validation in docker
+        self.validator.validate()
+        expected_sample_checker = {
             'overall_differences': False,
             'results_per_analysis': {
                 'AA': {
@@ -124,28 +152,45 @@ class TestDockerValidator(TestCase):
                 }
             }
         }
-        self.assert_sample_checker(self.validator._sample_check_yaml, expected_checker)
-
-        with open(self.validator.metadata_json_post_validation) as open_file:
-            json_data = json.load(open_file)
-            assert json_data.get('files') == [
-                {'analysisAlias': 'AA', 'fileName': 'input_passed.vcf', 'fileType': 'vcf',
-                 'md5': '96a80c9368cc3c37095c86fbe6044fb2', 'fileSize': 45050}
-            ]
-
-        # Check metadata errors
-        with open(os.path.join(self.validator.output_dir, 'other_validations', 'metadata_validation.txt')) as open_file:
-            metadata_val_lines = {l.strip() for l in open_file.readlines()}
-            assert 'must match pattern "^PRJ(EB|NA)\\d+$"' in metadata_val_lines
-
-        # Check semantic metadata errors
-        semantic_yaml_file = os.path.join(self.validator.output_dir, 'other_validations', 'metadata_semantic_check.yml')
-        self.assertTrue(os.path.isfile(semantic_yaml_file))
-        with open(semantic_yaml_file) as open_yaml:
-            semantic_output = yaml.safe_load(open_yaml)
-            assert semantic_output[1] == {'description': 'SAME123 does not exist or is private',
+        expected_metadata_files_json = [
+            {'analysisAlias': 'AA', 'fileName': 'input_passed.vcf', 'fileType': 'vcf',
+             'md5': '96a80c9368cc3c37095c86fbe6044fb2', 'fileSize': 45050}
+        ]
+        expected_metadata_val = 'must match pattern "^PRJ(EB|NA)\\d+$"'
+        expected_semantic_val = {'description': 'SAME123 does not exist or is private',
                                           'property': '/sample/0/bioSampleAccession'}
+
+        self.assess_post_validation(self.validator, expected_sample_checker, expected_metadata_files_json,
+                                    expected_metadata_val, expected_semantic_val)
 
     def test_validate_from_excel(self):
         self.validator_from_excel.validate()
         self.assertTrue(os.path.isfile(self.validator_from_excel._sample_check_yaml))
+        expected_sample_checker = {
+            'overall_differences': True,
+            'results_per_analysis': {
+                'No analysis': {'difference': True, 'more_metadata_submitted_files': [],
+                                'more_per_submitted_files_metadata': {'input_passed.vcf': ['HG00096']},
+                                'more_submitted_files_metadata': ['HG00096']},
+                'VD1': {'difference': True, 'more_metadata_submitted_files': ['sample2', 'sample1'],
+                        'more_per_submitted_files_metadata': {}, 'more_submitted_files_metadata': []},
+                'VD2': {'difference': True, 'more_metadata_submitted_files': ['sample2', 'sample1'],
+                        'more_per_submitted_files_metadata': {}, 'more_submitted_files_metadata': []},
+                'VD3': {'difference': True, 'more_metadata_submitted_files': ['sample3', 'sample2', 'sample1'],
+                        'more_per_submitted_files_metadata': {},'more_submitted_files_metadata': []},
+                'VD4': {'difference': True, 'more_metadata_submitted_files': ['sample4'],
+                        'more_per_submitted_files_metadata': {}, 'more_submitted_files_metadata': []},
+                'VD5': {'difference': True, 'more_metadata_submitted_files': ['sample4'],
+                        'more_per_submitted_files_metadata': {}, 'more_submitted_files_metadata': []}
+            }
+        }
+        expected_metadata_files_json = [
+            {'analysisAlias': 'VD1', 'fileName': 'example1.vcf.gz', 'fileSize': '', 'md5': ''},
+            {'analysisAlias': 'VD2', 'fileName': 'example2.vcf', 'fileSize': '', 'md5': ''},
+            {'analysisAlias': 'VD3', 'fileName': 'example3.vcf',  'fileSize': '', 'md5': ''}
+        ]
+        expected_metadata_val = 'Validation passed successfully.'
+        expected_semantic_val = {'description': 'Project PRJEB00002 does not exist in ENA or is private',
+                                 'property': '/project/childProjects/0'}
+        self.assess_post_validation(self.validator_from_excel, expected_sample_checker, expected_metadata_files_json,
+                                    expected_metadata_val, expected_semantic_val)


### PR DESCRIPTION
 - Ensure that docker stops at the end of the process
 - Ensure that two concurrent runs use a different docker process
 - Retry downloading the image if it fails the first time
 - Lock the submission directory at the start of the process to prevent multiple execution on the same directory