### PR TITLE
Remove pyutils pinned version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ ebi_eva_common_pyutils > 0.6.11, == 0.*
 jinja2 >= 3.0.0, ==3.*
 jsonschema == 4.*
 openpyxl == 3.*
-pyyaml ==  6.*
-requests >= 2.32, ==2.*
+pyyaml == 6.*
+requests == 2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-ebi_eva_common_pyutils
-jinja2
-jsonschema
-openpyxl
-pyyaml
-requests
-retry
+ebi_eva_common_pyutils > 0.6.11, == 0.*
+jinja2 >= 3.0.0, ==3.*
+jsonschema == 4.*
+openpyxl == 3.*
+pyyaml ==  6.*
+requests >= 2.32, ==2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ebi_eva_common_pyutils==0.6.11
+ebi_eva_common_pyutils
 jinja2
 jsonschema
 openpyxl

--- a/tests/test_semantic_metadata.py
+++ b/tests/test_semantic_metadata.py
@@ -158,11 +158,11 @@ class TestSemanticMetadata(TestCase):
             self.assertEqual(
                 checker.errors[1],
                 {'property': '/sample/2/bioSampleAccession',
-                 'description': "Existing sample SAME00003 should have required property 'collection date'"}
+                 'description': "Existing sample SAME00003 Just one of the following properties must be specified: 'collection_date', 'collection date', 'Event Date/Time'"}
             )
             # Final error message lists all possible geographic locations
             self.assertTrue(checker.errors[2]['description'].startswith(
-                'Existing sample SAME00003 should be equal to one of the allowed values:'))
+                'Existing sample SAME00003 must be equal to one of the allowed values:'))
 
     def test_check_existing_biosamples(self):
         checker = SemanticMetadataChecker(metadata, sample_checklist=None)


### PR DESCRIPTION
Slightly more relaxed version requirements.
Only pinning to a minimal version and a major version
