### PR TITLE
EVA-3819 - compress after trim down

### DIFF
--- a/eva_sub_cli/executables/trim_down.py
+++ b/eva_sub_cli/executables/trim_down.py
@@ -16,8 +16,9 @@ def trim_down_vcf(vcf_file, output_vcf, max_nb_lines=MAX_NB_LINES):
     """
     Produce a smaller vcf files containing a maximum of 10000 records
     """
-    with open_gzip_if_required(vcf_file) as vcf_in, open(output_vcf, 'w') as vcf_out:
+    with open_gzip_if_required(vcf_file) as vcf_in, open_gzip_if_required(output_vcf, 'w') as vcf_out:
         line_count = 0
+        trimmed_down = False
         ref_seq_names = set()
         for line in vcf_in:
             if line.startswith('#') or line_count < max_nb_lines:
@@ -26,13 +27,8 @@ def trim_down_vcf(vcf_file, output_vcf, max_nb_lines=MAX_NB_LINES):
                     line_count += 1
                     ref_seq_names.add(line.split('\t')[0])
             else:
+                trimmed_down = True
                 break
-        # Check if there are more lines:
-        trimmed_down = True
-        try:
-            next(vcf_in)
-        except StopIteration:
-            trimmed_down = False
     if line_count != max_nb_lines:
         logger.warning(f'Only {line_count} found in the source VCF {vcf_file} ')
 

--- a/eva_sub_cli/file_utils.py
+++ b/eva_sub_cli/file_utils.py
@@ -46,12 +46,12 @@ def backup_file_or_directory(file_name, max_backups=None):
     os.rename(file_name, file_name + '.1')
 
 
-def open_gzip_if_required(input_file):
+def open_gzip_if_required(input_file, mode='r'):
     """Open a file in read mode using gzip if the file extension says .gz"""
     if input_file.endswith('.gz'):
-        return gzip.open(input_file, 'rt')
+        return gzip.open(input_file, mode + 't')
     else:
-        return open(input_file, 'r')
+        return open(input_file, mode)
 
 
 def fasta_iter(input_fasta):

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -112,16 +112,14 @@ process trim_down_vcf {
     tuple path(vcf), path(fasta), path(report)
 
     output:
-    tuple path("output/$output_vcf"), path("output/$fasta"), path(report), emit: vcf_and_ref
+    tuple path("output/$vcf"), path("output/$fasta"), path(report), emit: vcf_and_ref
     path "${vcf.getBaseName()}_trim_down.log", emit: trim_down_log
     path "${vcf.getBaseName()}_trim_down.yml", emit: trim_down_metric
 
     script:
-    def vcfname = vcf.getName()
-    output_vcf = vcfname.endsWith('.gz') ? vcfname[0..-4] : vcfname
     """
     mkdir output
-    $params.python_scripts.trim_down --vcf_file $vcf  --output_vcf_file output/$output_vcf --fasta_file $fasta --output_fasta_file output/$fasta --output_yaml_file ${vcf.getBaseName()}_trim_down.yml > ${vcf.getBaseName()}_trim_down.log
+    $params.python_scripts.trim_down --vcf_file $vcf  --output_vcf_file output/$vcf --fasta_file $fasta --output_fasta_file output/$fasta --output_yaml_file ${vcf.getBaseName()}_trim_down.yml > ${vcf.getBaseName()}_trim_down.log
     # This is needed to ensure that a missing (NO_FILE) report can still be passed down to subsequent steps
     touch $report
     """


### PR DESCRIPTION
Revert trim down naming change in nextflow and ensure it generate a gzip file when the output has a gzip extension.
Changing the name of the vcf files (by removing the '.gz') prevent the association of the validation results with the correct VCF file. 