### PR TITLE
Eva3509 caseinsensitive metadata

### DIFF
--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -4,13 +4,25 @@ import json
 from ebi_eva_common_pyutils.logger import logging_config
 logger = logging_config.get_logger(__name__)
 
-def format_experiment_type_lowercase(json_file_input, json_file_output):
+def format_experiment_type(json_file_input, json_file_output):
     with open(json_file_input, 'r') as input:
         json_data = json.load(input)
 
+    experiment_type_mapping = {
+        "whole genome sequencing": "Whole genome sequencing",
+        "whole transcriptome sequencing": "Whole transcriptome sequencing",
+        "exome sequencing": "Exome sequencing",
+        "genotyping by array": "Genotyping by array",
+        "curation": "Curation",
+        "genotyping by sequencing": "Genotyping by sequencing",
+        "target sequencing": "Target sequencing",
+        "transcriptomics": "Transcriptomics"
+    }
     for index in range(len(json_data["analysis"])):
         logger.info(f"Formatting metadata - experiment type to lower case - {json_data['analysis'][index]['experimentType']}")
-        json_data["analysis"][index]["experimentType"] = json_data["analysis"][index]["experimentType"].lower()
+        experiment_type_lower_case = json_data["analysis"][index]["experimentType"].lower()
+        experiment_type = experiment_type_mapping[experiment_type_lower_case]
+        json_data["analysis"][index]["experimentType"] = experiment_type
 
     with open(json_file_output, 'w') as output:
         json.dump(json_data, output, indent=4)
@@ -24,7 +36,7 @@ def main():
     arg_parser.add_argument('--metadata_json_output', required=True, dest='metadata_json_output',
                             help='EVA metadata json file OUTPUT')
     args = arg_parser.parse_args()
-    format_experiment_type_lowercase(args.metadata_json_input, args.metadata_json_output)
+    format_experiment_type(args.metadata_json_input, args.metadata_json_output)
 
 if __name__ == "__main__":
     main()

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -1,0 +1,20 @@
+import argparse
+from ebi_eva_common_pyutils.logger import logging_config
+logger = logging_config.get_logger(__name__)
+
+def format_experiment_type_lowercase(json):
+    for index in range(len(json["analysis"])):
+        logger.info(f"Formating metadata - experiment type to lower case - {json["analysis"][index]["experimentType"]}")
+        json["analysis"][index]["experimentType"] = json["analysis"][index]["experimentType"].lower()
+    return json
+
+def main():
+    arg_parser = argparse.ArgumentParser(
+        description='Formats experiment type for the metadata.')
+    arg_parser.add_argument('--metadata_json', required=True, dest='metadata_json',
+                            help='EVA metadata json file')
+    args = arg_parser.parse_args()
+    format_experiment_type_lowercase(args.metadata_json)
+
+if __name__ == "__main__":
+    main()

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -11,23 +11,11 @@ def format_experiment_type(json_file_input, json_file_output):
         with open(json_file_input, 'r') as input:
             json_data = json.load(input)
 
-        experiment_type_mapping = {
-            "whole genome sequencing": "Whole genome sequencing",
-            "whole transcriptome sequencing": "Whole transcriptome sequencing",
-            "exome sequencing": "Exome sequencing",
-            "genotyping by array": "Genotyping by array",
-            "curation": "Curation",
-            "genotyping by sequencing": "Genotyping by sequencing",
-            "target sequencing": "Target sequencing",
-            "transcriptomics": "Transcriptomics"
-        }
-
         for analysis_item in json_data.get("analysis", []):
             original_experiment_type = analysis_item.get("experimentType", "")
-            logger.info(f"Formatting metadata - experiment type to lower case - {original_experiment_type}")
-            experiment_type_lower_case = original_experiment_type.lower()
-            experiment_type = experiment_type_mapping.get(experiment_type_lower_case, original_experiment_type)
-            analysis_item["experimentType"] = experiment_type
+            logger.info(f"Formatting metadata - experiment type to capitalized - {original_experiment_type}")
+            experiment_type_capital = original_experiment_type.capitalize()
+            analysis_item["experimentType"] = experiment_type_capital or ""
 
         with open(json_file_output, 'w') as output:
             json.dump(json_data, output, indent=4)

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import shutil
+
 from ebi_eva_common_pyutils.logger import logging_config
 logger = logging_config.get_logger(__name__)
 
@@ -32,8 +34,10 @@ def format_experiment_type(json_file_input, json_file_output):
         return json_file_output
 
     except (FileNotFoundError, json.JSONDecodeError, KeyError) as e:
+        # if the try block fails, copy the input file (because nextflow is expecting the output file).
         logger.error(f"Failed to process JSON: {e}")
-        return json_file_input
+        shutil.copy(json_file_input, json_file_output)
+        return None
 
 
 def main():

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -4,25 +4,27 @@ import json
 from ebi_eva_common_pyutils.logger import logging_config
 logger = logging_config.get_logger(__name__)
 
-def format_experiment_type_lowercase(json_file):
-    with open(json_file, 'r') as file:
-        json_data = json.load(file)
+def format_experiment_type_lowercase(json_file_input, json_file_output):
+    with open(json_file_input, 'r') as input:
+        json_data = json.load(input)
 
     for index in range(len(json_data["analysis"])):
         logger.info(f"Formatting metadata - experiment type to lower case - {json_data['analysis'][index]['experimentType']}")
         json_data["analysis"][index]["experimentType"] = json_data["analysis"][index]["experimentType"].lower()
 
-    with open(json_file, 'w') as file:
-        json.dump(json_data, file, indent=4)
-    return json_file
+    with open(json_file_output, 'w') as output:
+        json.dump(json_data, output, indent=4)
+    return json_file_output
 
 def main():
     arg_parser = argparse.ArgumentParser(
         description='Formats experiment type for the metadata.')
-    arg_parser.add_argument('--metadata_json', required=True, dest='metadata_json',
-                            help='EVA metadata json file')
+    arg_parser.add_argument('--metadata_json_input', required=True, dest='metadata_json_input',
+                            help='EVA metadata json file INPUT')
+    arg_parser.add_argument('--metadata_json_output', required=True, dest='metadata_json_output',
+                            help='EVA metadata json file OUTPUT')
     args = arg_parser.parse_args()
-    format_experiment_type_lowercase(args.metadata_json)
+    format_experiment_type_lowercase(args.metadata_json_input, args.metadata_json_output)
 
 if __name__ == "__main__":
     main()

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -1,0 +1,27 @@
+import argparse
+import json
+from ebi_eva_common_pyutils.logger import logging_config
+logger = logging_config.get_logger(__name__)
+
+def format_experiment_type_lowercase(json_file):
+    with open(json_file, 'r') as file:
+        json_data = json.load(file)
+
+    for index in range(len(json_data["analysis"])):
+        logger.info(f"Formatting metadata - experiment type to lower case - {json_data["analysis"][index]["experimentType"]}")
+        json_data["analysis"][index]["experimentType"] = json_data["analysis"][index]["experimentType"].lower()
+
+    with open(json_file, 'w') as file:
+        json.dump(json_data, file, indent=4)
+    return json_file
+
+def main():
+    arg_parser = argparse.ArgumentParser(
+        description='Formats experiment type for the metadata.')
+    arg_parser.add_argument('--metadata_json', required=True, dest='metadata_json',
+                            help='EVA metadata json file')
+    args = arg_parser.parse_args()
+    format_experiment_type_lowercase(args.metadata_json)
+
+if __name__ == "__main__":
+    main()

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -33,7 +33,7 @@ def format_experiment_type(json_file_input, json_file_output):
 
     except (FileNotFoundError, json.JSONDecodeError, KeyError) as e:
         logger.error(f"Failed to process JSON: {e}")
-        return None
+        return json_file_input
 
 
 def main():

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -5,28 +5,36 @@ from ebi_eva_common_pyutils.logger import logging_config
 logger = logging_config.get_logger(__name__)
 
 def format_experiment_type(json_file_input, json_file_output):
-    with open(json_file_input, 'r') as input:
-        json_data = json.load(input)
+    try:
+        with open(json_file_input, 'r') as input:
+            json_data = json.load(input)
 
-    experiment_type_mapping = {
-        "whole genome sequencing": "Whole genome sequencing",
-        "whole transcriptome sequencing": "Whole transcriptome sequencing",
-        "exome sequencing": "Exome sequencing",
-        "genotyping by array": "Genotyping by array",
-        "curation": "Curation",
-        "genotyping by sequencing": "Genotyping by sequencing",
-        "target sequencing": "Target sequencing",
-        "transcriptomics": "Transcriptomics"
-    }
-    for index in range(len(json_data["analysis"])):
-        logger.info(f"Formatting metadata - experiment type to lower case - {json_data['analysis'][index]['experimentType']}")
-        experiment_type_lower_case = json_data["analysis"][index]["experimentType"].lower()
-        experiment_type = experiment_type_mapping[experiment_type_lower_case]
-        json_data["analysis"][index]["experimentType"] = experiment_type
+        experiment_type_mapping = {
+            "whole genome sequencing": "Whole genome sequencing",
+            "whole transcriptome sequencing": "Whole transcriptome sequencing",
+            "exome sequencing": "Exome sequencing",
+            "genotyping by array": "Genotyping by array",
+            "curation": "Curation",
+            "genotyping by sequencing": "Genotyping by sequencing",
+            "target sequencing": "Target sequencing",
+            "transcriptomics": "Transcriptomics"
+        }
 
-    with open(json_file_output, 'w') as output:
-        json.dump(json_data, output, indent=4)
-    return json_file_output
+        for analysis_item in json_data.get("analysis", []):
+            original_experiment_type = analysis_item.get("experimentType", "")
+            logger.info(f"Formatting metadata - experiment type to lower case - {original_experiment_type}")
+            experiment_type_lower_case = original_experiment_type.lower()
+            experiment_type = experiment_type_mapping.get(experiment_type_lower_case, original_experiment_type)
+            analysis_item["experimentType"] = experiment_type
+
+        with open(json_file_output, 'w') as output:
+            json.dump(json_data, output, indent=4)
+        return json_file_output
+
+    except (FileNotFoundError, json.JSONDecodeError, KeyError) as e:
+        logger.error(f"Failed to process JSON: {e}")
+        return None
+
 
 def main():
     arg_parser = argparse.ArgumentParser(

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -8,7 +8,7 @@ def format_experiment_type_lowercase(json_file):
         json_data = json.load(file)
 
     for index in range(len(json_data["analysis"])):
-        logger.info(f"Formatting metadata - experiment type to lower case - {json_data["analysis"][index]["experimentType"]}")
+        logger.info(f"Formatting metadata - experiment type to lower case - {json_data['analysis'][index]['experimentType']}")
         json_data["analysis"][index]["experimentType"] = json_data["analysis"][index]["experimentType"].lower()
 
     with open(json_file, 'w') as file:

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import json
 from ebi_eva_common_pyutils.logger import logging_config

--- a/eva_sub_cli/executables/format_metadata.py
+++ b/eva_sub_cli/executables/format_metadata.py
@@ -4,25 +4,39 @@ import json
 from ebi_eva_common_pyutils.logger import logging_config
 logger = logging_config.get_logger(__name__)
 
-def format_experiment_type_lowercase(json_file):
-    with open(json_file, 'r') as file:
-        json_data = json.load(file)
+def format_experiment_type(json_file_input, json_file_output):
+    with open(json_file_input, 'r') as input:
+        json_data = json.load(input)
 
+    experiment_type_mapping = {
+        "whole genome sequencing": "Whole genome sequencing",
+        "whole transcriptome sequencing": "Whole transcriptome sequencing",
+        "exome sequencing": "Exome sequencing",
+        "genotyping by array": "Genotyping by array",
+        "curation": "Curation",
+        "genotyping by sequencing": "Genotyping by sequencing",
+        "target sequencing": "Target sequencing",
+        "transcriptomics": "Transcriptomics"
+    }
     for index in range(len(json_data["analysis"])):
         logger.info(f"Formatting metadata - experiment type to lower case - {json_data['analysis'][index]['experimentType']}")
-        json_data["analysis"][index]["experimentType"] = json_data["analysis"][index]["experimentType"].lower()
+        experiment_type_lower_case = json_data["analysis"][index]["experimentType"].lower()
+        experiment_type = experiment_type_mapping[experiment_type_lower_case]
+        json_data["analysis"][index]["experimentType"] = experiment_type
 
-    with open(json_file, 'w') as file:
-        json.dump(json_data, file, indent=4)
-    return json_file
+    with open(json_file_output, 'w') as output:
+        json.dump(json_data, output, indent=4)
+    return json_file_output
 
 def main():
     arg_parser = argparse.ArgumentParser(
         description='Formats experiment type for the metadata.')
-    arg_parser.add_argument('--metadata_json', required=True, dest='metadata_json',
-                            help='EVA metadata json file')
+    arg_parser.add_argument('--metadata_json_input', required=True, dest='metadata_json_input',
+                            help='EVA metadata json file INPUT')
+    arg_parser.add_argument('--metadata_json_output', required=True, dest='metadata_json_output',
+                            help='EVA metadata json file OUTPUT')
     args = arg_parser.parse_args()
-    format_experiment_type_lowercase(args.metadata_json)
+    format_experiment_type(args.metadata_json_input, args.metadata_json_output)
 
 if __name__ == "__main__":
     main()

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -103,6 +103,7 @@ workflow {
 	}
 
     metadata_json_format(metadata_json)
+    metadata_json = metadata_json_format.out.metadata_formatted_json
 	// File size and MD5
 	generate_file_size_and_md5_digests(vcf_files)
 	collect_file_size_and_md5(generate_file_size_and_md5_digests.out.file_size_and_digest_info.collect())
@@ -311,7 +312,7 @@ process metadata_json_validation {
     path(output_json)
 
     output:
-    path "metadata_formatted.json", emit: metadata_validation
+    path "metadata_validation.txt", emit: metadata_validation
 
     script:
     """

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -43,7 +43,7 @@ params.python_scripts = [
     "xlsx2json": "xlsx2json.py",
     "semantic_checker": "check_metadata_semantics.py",
     "trim_down": "trim_down.py",
-    "format_metadata": "/YOUR/PATH/TO/PycharmProjects/eva-sub-cli/eva_sub_cli/executables/format_metadata.py"
+    "format_metadata": "format_metadata.py"
 ]
 // prefix to prepend to all provided path
 params.base_dir = ""
@@ -295,7 +295,7 @@ process metadata_json_format {
     //python $params.python_scripts.format_metadata --metadata_json $metadata_json > metadata_formatted.log 2>&1
     """
     cp $params.python_scripts.format_metadata .
-    python format_metadata.py --metadata_json $metadata_json > metadata_formatted.log 2>&1
+    format_metadata.py --metadata_json $metadata_json > metadata_formatted.log 2>&1
     """
 }
 

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -309,14 +309,14 @@ process metadata_json_validation {
             mode: "copy"
 
     input:
-    path(output_json)
+    path(metadata_json)
 
     output:
     path "metadata_validation.txt", emit: metadata_validation
 
     script:
     """
-    $params.executable.biovalidator --schema $schema_dir/eva_schema.json --ref $schema_dir/eva-biosamples.json --data $output_json > metadata_validation.txt 2>&1
+    $params.executable.biovalidator --schema $schema_dir/eva_schema.json --ref $schema_dir/eva-biosamples.json --data $metadata_json > metadata_validation.txt 2>&1
     """
 }
 

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -42,7 +42,8 @@ params.python_scripts = [
     "fasta_checker": "check_fasta_insdc.py",
     "xlsx2json": "xlsx2json.py",
     "semantic_checker": "check_metadata_semantics.py",
-    "trim_down": "trim_down.py"
+    "trim_down": "trim_down.py",
+    "format_metadata": "format_metadata.json"
 ]
 // prefix to prepend to all provided path
 params.base_dir = ""
@@ -99,7 +100,9 @@ workflow {
 		metadata_json = convert_xlsx_2_json.out.metadata_json
 	} else {
 		metadata_json = joinBasePath(params.metadata_json)
+		//metadata_json = Channel.fromPath(joinBasePath(params.metadata_json))
 	}
+	metadata_json_format(metadata_json)
 	// File size and MD5
 	generate_file_size_and_md5_digests(vcf_files)
 	collect_file_size_and_md5(generate_file_size_and_md5_digests.out.file_size_and_digest_info.collect())
@@ -274,6 +277,26 @@ process convert_xlsx_2_json {
     """
 }
 
+process metadata_json_format {
+
+    label 'short_time', 'small_mem'
+
+    publishDir output_dir,
+            overwrite: true,
+            mode: "copy"
+
+    input:
+    path(metadata_json)
+
+    output:
+    path "metadata_formatted.log", emit: metadata_formatted
+
+    script:
+    """
+    $params.python_scripts.format_metadata --metadata_json $metadata_json > metadata_formatted.log 2>&1
+    """
+}
+
 process metadata_json_validation {
 
     label 'short_time', 'small_mem'
@@ -286,7 +309,7 @@ process metadata_json_validation {
     path(metadata_json)
 
     output:
-    path "metadata_validation.txt", emit: metadata_validation
+    path "metadata_formatted.json", emit: metadata_validation
 
     script:
     """

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -308,14 +308,14 @@ process metadata_json_validation {
             mode: "copy"
 
     input:
-    path(metadata_json)
+    path(output_json)
 
     output:
     path "metadata_formatted.json", emit: metadata_validation
 
     script:
     """
-    $params.executable.biovalidator --schema $schema_dir/eva_schema.json --ref $schema_dir/eva-biosamples.json --data $metadata_json > metadata_validation.txt 2>&1
+    $params.executable.biovalidator --schema $schema_dir/eva_schema.json --ref $schema_dir/eva-biosamples.json --data $output_json > metadata_validation.txt 2>&1
     """
 }
 

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -42,7 +42,8 @@ params.python_scripts = [
     "fasta_checker": "check_fasta_insdc.py",
     "xlsx2json": "xlsx2json.py",
     "semantic_checker": "check_metadata_semantics.py",
-    "trim_down": "trim_down.py"
+    "trim_down": "trim_down.py",
+    "format_metadata": "/YOUR/PATH/TO/PycharmProjects/eva-sub-cli/eva_sub_cli/executables/format_metadata.py"
 ]
 // prefix to prepend to all provided path
 params.base_dir = ""
@@ -98,8 +99,10 @@ workflow {
 		convert_xlsx_2_json(joinBasePath(params.metadata_xlsx))
 		metadata_json = convert_xlsx_2_json.out.metadata_json
 	} else {
-		metadata_json = joinBasePath(params.metadata_json)
+		metadata_json = file(joinBasePath(params.metadata_json), checkIfExists:true)
 	}
+
+    metadata_json_format(metadata_json)
 	// File size and MD5
 	generate_file_size_and_md5_digests(vcf_files)
 	collect_file_size_and_md5(generate_file_size_and_md5_digests.out.file_size_and_digest_info.collect())
@@ -274,6 +277,29 @@ process convert_xlsx_2_json {
     """
 }
 
+process metadata_json_format {
+
+    label 'short_time', 'small_mem'
+
+    publishDir output_dir,
+            overwrite: true,
+            mode: "copy"
+
+    input:
+    path(metadata_json)
+
+    output:
+    path "metadata_formatted.log", emit: metadata_formatted
+
+    script:
+    // THIS WORKS
+    //python $params.python_scripts.format_metadata --metadata_json $metadata_json > metadata_formatted.log 2>&1
+    """
+    cp $params.python_scripts.format_metadata .
+    python format_metadata.py --metadata_json $metadata_json > metadata_formatted.log 2>&1
+    """
+}
+
 process metadata_json_validation {
 
     label 'short_time', 'small_mem'
@@ -286,7 +312,7 @@ process metadata_json_validation {
     path(metadata_json)
 
     output:
-    path "metadata_validation.txt", emit: metadata_validation
+    path "metadata_formatted.json", emit: metadata_validation
 
     script:
     """

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -103,6 +103,7 @@ workflow {
 	}
 
     metadata_json_format(metadata_json)
+    metadata_json = metadata_json_format.out.metadata_formatted_json
 	// File size and MD5
 	generate_file_size_and_md5_digests(vcf_files)
 	collect_file_size_and_md5(generate_file_size_and_md5_digests.out.file_size_and_digest_info.collect())
@@ -290,10 +291,12 @@ process metadata_json_format {
 
     output:
     path "metadata_formatted.log", emit: metadata_formatted
+    path "metadata_formatted_case_insensitive.json", emit: metadata_formatted_json
 
     script:
+    def output_json = "metadata_formatted_case_insensitive.json"
     """
-    format_metadata.py --metadata_json $metadata_json > metadata_formatted.log 2>&1
+    format_metadata.py --metadata_json_input $metadata_json --metadata_json_output $output_json > metadata_formatted.log 2>&1
     """
 }
 
@@ -306,14 +309,14 @@ process metadata_json_validation {
             mode: "copy"
 
     input:
-    path(metadata_json)
+    path(output_json)
 
     output:
-    path "metadata_formatted.json", emit: metadata_validation
+    path "metadata_validation.txt", emit: metadata_validation
 
     script:
     """
-    $params.executable.biovalidator --schema $schema_dir/eva_schema.json --ref $schema_dir/eva-biosamples.json --data $metadata_json > metadata_validation.txt 2>&1
+    $params.executable.biovalidator --schema $schema_dir/eva_schema.json --ref $schema_dir/eva-biosamples.json --data $output_json > metadata_validation.txt 2>&1
     """
 }
 

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -292,9 +292,7 @@ process metadata_json_format {
     path "metadata_formatted.log", emit: metadata_formatted
 
     script:
-    //python $params.python_scripts.format_metadata --metadata_json $metadata_json > metadata_formatted.log 2>&1
     """
-    cp $params.python_scripts.format_metadata .
     format_metadata.py --metadata_json $metadata_json > metadata_formatted.log 2>&1
     """
 }

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -290,10 +290,12 @@ process metadata_json_format {
 
     output:
     path "metadata_formatted.log", emit: metadata_formatted
+    path "metadata_formatted_case_insensitive.json", emit: metadata_formatted_json
 
     script:
+    def output_json = "metadata_formatted_case_insensitive.json"
     """
-    format_metadata.py --metadata_json $metadata_json > metadata_formatted.log 2>&1
+    format_metadata.py --metadata_json_input $metadata_json --metadata_json_output $output_json > metadata_formatted.log 2>&1
     """
 }
 

--- a/eva_sub_cli/nextflow/validation.nf
+++ b/eva_sub_cli/nextflow/validation.nf
@@ -43,7 +43,7 @@ params.python_scripts = [
     "xlsx2json": "xlsx2json.py",
     "semantic_checker": "check_metadata_semantics.py",
     "trim_down": "trim_down.py",
-    "format_metadata": "/YOUR/PATH/TO/PycharmProjects/eva-sub-cli/eva_sub_cli/executables/format_metadata.py"
+    "format_metadata": "format_metadata.py"
 ]
 // prefix to prepend to all provided path
 params.base_dir = ""
@@ -292,10 +292,8 @@ process metadata_json_format {
     path "metadata_formatted.log", emit: metadata_formatted
 
     script:
-    //python $params.python_scripts.format_metadata --metadata_json $metadata_json > metadata_formatted.log 2>&1
     """
-    cp $params.python_scripts.format_metadata .
-    python format_metadata.py --metadata_json $metadata_json > metadata_formatted.log 2>&1
+    format_metadata.py --metadata_json $metadata_json > metadata_formatted.log 2>&1
     """
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 'evidence_type_checker.py'='eva_sub_cli.executables.evidence_type_checker:main'
 'xlsx2json.py'='eva_sub_cli.executables.xlsx2json:main'
 'trim_down.py'='eva_sub_cli.executables.trim_down:main'
+'format_metadata.py'='eva_sub_cli.executables.format_metadata:main'
 
 [tool.setuptools]
 packages = ['eva_sub_cli', 'eva_sub_cli.exceptions', 'eva_sub_cli.executables', 'eva_sub_cli.validators']

--- a/tests/test_format_metadata.py
+++ b/tests/test_format_metadata.py
@@ -1,4 +1,4 @@
-
+import os.path
 from unittest import TestCase
 from eva_sub_cli.executables import format_metadata
 import tempfile
@@ -7,12 +7,15 @@ import json
 class TestValidateMetadata(TestCase):
 
     def test_format_experiment_type(self):
+        expected_experiment_type = "Genotyping by array"
+        unexpected_experiment_type = "GeNoTyPiNg By ArRaY"
+        # testing a correctly formatted JSON file
         clean_json =  {
             "submitterDetails": [{"lastName": "", "firstName": "", "email": "", "laboratory": "", "centre": ""}],
             "project": {"title": "", "description": "", "taxId": 9606, "centre": ""},
             "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
                     # CHANGING THE LINE BELOW
-                    "experimentType": "Genotyping by array",
+                    "experimentType": expected_experiment_type,
                     "referenceGenome": ""}],
             "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
             "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
@@ -28,13 +31,18 @@ class TestValidateMetadata(TestCase):
             result_data = json.load(f)
         expected = clean_json
         self.assertEqual(result_data, expected)
-
+        self.assertEqual(result_data["analysis"][0]["experimentType"], expected_experiment_type)
+        if os.path.exists(temp_path_clean_output):
+            os.remove(temp_path_clean_output)
+        if os.path.exists(temp_path_clean):
+            os.remove(temp_path_clean)
+        # testing an incorrectly formatted JSON file
         unclean_json = {
             "submitterDetails": [{"lastName": "", "firstName": "", "email": "", "laboratory": "", "centre": ""}],
             "project": {"title": "", "description": "", "taxId": 9606, "centre": "",},
             "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
                     # CHANGING THE LINE BELOW
-                    "experimentType": "GeNoTyPiNg By ArRaY",
+                    "experimentType": unexpected_experiment_type,
                     "referenceGenome": ""}],
             "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
             "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
@@ -47,5 +55,10 @@ class TestValidateMetadata(TestCase):
         format_metadata.format_experiment_type(temp_path_unclean, temp_path_unclean_output)
         with open(temp_path_unclean_output, 'r') as f:
             result_data = json.load(f)
-        expected = unclean_json
-        self.assertNotEqual(result_data, expected)
+        expected = clean_json
+        self.assertEqual(result_data, expected)
+        self.assertEqual(result_data["analysis"][0]["experimentType"], expected_experiment_type)
+        if os.path.exists(temp_path_unclean_output):
+            os.remove(temp_path_unclean_output)
+        if os.path.exists(temp_path_unclean):
+            os.remove(temp_path_unclean)

--- a/tests/test_format_metadata.py
+++ b/tests/test_format_metadata.py
@@ -6,22 +6,25 @@ import json
 
 class TestValidateMetadata(TestCase):
 
-    def test_format_experiment_type_lowercase(self):
+    def test_format_experiment_type(self):
         clean_json =  {
             "submitterDetails": [{"lastName": "", "firstName": "", "email": "", "laboratory": "", "centre": ""}],
             "project": {"title": "", "description": "", "taxId": 9606, "centre": ""},
             "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
                     # CHANGING THE LINE BELOW
-                    "experimentType": "genotyping_by_array",
+                    "experimentType": "Genotyping by array",
                     "referenceGenome": ""}],
             "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
             "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
         }
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_out_clean:
+            temp_path_clean_output = tmp_out_clean.name
+            tmp_out_clean.write('')
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
             json.dump(clean_json, tmp)
             temp_path_clean = tmp.name
-        validated_result = format_metadata.format_experiment_type_lowercase(temp_path_clean)
-        with open(validated_result, 'r') as f:
+        format_metadata.format_experiment_type(temp_path_clean, temp_path_clean_output)
+        with open(temp_path_clean_output, 'r') as f:
             result_data = json.load(f)
         expected = clean_json
         self.assertEqual(result_data, expected)
@@ -31,16 +34,18 @@ class TestValidateMetadata(TestCase):
             "project": {"title": "", "description": "", "taxId": 9606, "centre": "",},
             "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
                     # CHANGING THE LINE BELOW
-                    "experimentType": "Genotyping_by_array",
+                    "experimentType": "GeNoTyPiNg By ArRaY",
                     "referenceGenome": ""}],
             "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
             "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
         }
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_out_unclean:
+            temp_path_unclean_output = tmp_out_unclean.name
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
             json.dump(unclean_json, tmp)
             temp_path_unclean = tmp.name
-        validated_result = format_metadata.format_experiment_type_lowercase(temp_path_unclean)
-        with open(validated_result, 'r') as f:
+        format_metadata.format_experiment_type(temp_path_unclean, temp_path_unclean_output)
+        with open(temp_path_unclean_output, 'r') as f:
             result_data = json.load(f)
         expected = unclean_json
         self.assertNotEqual(result_data, expected)

--- a/tests/test_format_metadata.py
+++ b/tests/test_format_metadata.py
@@ -1,0 +1,35 @@
+
+from unittest import TestCase
+from eva_sub_cli.executables import format_metadata
+
+
+class TestValidateMetadata(TestCase):
+
+    def test_format_experiment_type_lowercase(self):
+        clean_json = {
+            "submitterDetails": [{"lastName": "", "firstName": "", "email": "", "laboratory": "", "centre": ""}],
+            "project": {"title": "", "description": "", "taxId": 9606, "centre": ""},
+            "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
+                    # CHANGING THE LINE BELOW
+                    "experimentType": "genotyping_by_array",
+                    "referenceGenome": ""}],
+            "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
+            "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
+        }
+        validated_result = format_metadata.format_experiment_type_lowercase(clean_json)
+        expected = clean_json
+        self.assertEqual(validated_result, expected)
+
+        unclean_json = {
+            "submitterDetails": [{"lastName": "", "firstName": "", "email": "", "laboratory": "", "centre": ""}],
+            "project": {"title": "", "description": "", "taxId": 9606, "centre": "",},
+            "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
+                    # CHANGING THE LINE BELOW
+                    "experimentType": "Genotyping_by_array",
+                    "referenceGenome": ""}],
+            "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
+            "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
+        }
+        validated_result = format_metadata.format_experiment_type_lowercase(unclean_json)
+        expected = clean_json
+        self.assertEqual(validated_result, expected)

--- a/tests/test_format_metadata.py
+++ b/tests/test_format_metadata.py
@@ -17,11 +17,14 @@ class TestValidateMetadata(TestCase):
             "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
             "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
         }
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_out_clean:
+            temp_path_clean_output = tmp_out_clean.name
+            tmp_out_clean.write('')
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
             json.dump(clean_json, tmp)
             temp_path_clean = tmp.name
-        validated_result = format_metadata.format_experiment_type_lowercase(temp_path_clean)
-        with open(validated_result, 'r') as f:
+        format_metadata.format_experiment_type_lowercase(temp_path_clean, temp_path_clean_output)
+        with open(temp_path_clean_output, 'r') as f:
             result_data = json.load(f)
         expected = clean_json
         self.assertEqual(result_data, expected)
@@ -36,11 +39,13 @@ class TestValidateMetadata(TestCase):
             "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
             "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
         }
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp_out_unclean:
+            temp_path_unclean_output = tmp_out_unclean.name
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
             json.dump(unclean_json, tmp)
             temp_path_unclean = tmp.name
-        validated_result = format_metadata.format_experiment_type_lowercase(temp_path_unclean)
-        with open(validated_result, 'r') as f:
+        format_metadata.format_experiment_type_lowercase(temp_path_unclean, temp_path_unclean_output)
+        with open(temp_path_unclean_output, 'r') as f:
             result_data = json.load(f)
         expected = unclean_json
         self.assertNotEqual(result_data, expected)

--- a/tests/test_format_metadata.py
+++ b/tests/test_format_metadata.py
@@ -1,0 +1,47 @@
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+from eva_sub_cli.executables import format_metadata
+import tempfile
+import json
+
+class TestValidateMetadata(TestCase):
+
+    def test_format_experiment_type_lowercase(self):
+        clean_json =  {
+            "submitterDetails": [{"lastName": "", "firstName": "", "email": "", "laboratory": "", "centre": ""}],
+            "project": {"title": "", "description": "", "taxId": 9606, "centre": ""},
+            "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
+                    # CHANGING THE LINE BELOW
+                    "experimentType": "genotyping_by_array",
+                    "referenceGenome": ""}],
+            "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
+            "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
+        }
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+            json.dump(clean_json, tmp)
+            temp_path_clean = tmp.name
+        validated_result = format_metadata.format_experiment_type_lowercase(temp_path_clean)
+        with open(validated_result, 'r') as f:
+            result_data = json.load(f)
+        expected = clean_json
+        self.assertEqual(result_data, expected)
+
+        unclean_json = {
+            "submitterDetails": [{"lastName": "", "firstName": "", "email": "", "laboratory": "", "centre": ""}],
+            "project": {"title": "", "description": "", "taxId": 9606, "centre": "",},
+            "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
+                    # CHANGING THE LINE BELOW
+                    "experimentType": "Genotyping_by_array",
+                    "referenceGenome": ""}],
+            "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
+            "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
+        }
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+            json.dump(unclean_json, tmp)
+            temp_path_unclean = tmp.name
+        validated_result = format_metadata.format_experiment_type_lowercase(temp_path_unclean)
+        with open(validated_result, 'r') as f:
+            result_data = json.load(f)
+        expected = unclean_json
+        self.assertNotEqual(result_data, expected)

--- a/tests/test_format_metadata.py
+++ b/tests/test_format_metadata.py
@@ -6,13 +6,13 @@ import json
 
 class TestValidateMetadata(TestCase):
 
-    def test_format_experiment_type_lowercase(self):
+    def test_format_experiment_type(self):
         clean_json =  {
             "submitterDetails": [{"lastName": "", "firstName": "", "email": "", "laboratory": "", "centre": ""}],
             "project": {"title": "", "description": "", "taxId": 9606, "centre": ""},
             "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
                     # CHANGING THE LINE BELOW
-                    "experimentType": "genotyping_by_array",
+                    "experimentType": "Genotyping by array",
                     "referenceGenome": ""}],
             "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
             "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
@@ -23,7 +23,7 @@ class TestValidateMetadata(TestCase):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
             json.dump(clean_json, tmp)
             temp_path_clean = tmp.name
-        format_metadata.format_experiment_type_lowercase(temp_path_clean, temp_path_clean_output)
+        format_metadata.format_experiment_type(temp_path_clean, temp_path_clean_output)
         with open(temp_path_clean_output, 'r') as f:
             result_data = json.load(f)
         expected = clean_json
@@ -34,7 +34,7 @@ class TestValidateMetadata(TestCase):
             "project": {"title": "", "description": "", "taxId": 9606, "centre": "",},
             "analysis": [{"analysisTitle": "", "analysisAlias": "", "description": "",
                     # CHANGING THE LINE BELOW
-                    "experimentType": "Genotyping_by_array",
+                    "experimentType": "GeNoTyPiNg By ArRaY",
                     "referenceGenome": ""}],
             "sample": [{"analysisAlias": [""], "sampleInVCF": "", "bioSampleObject": {"sample_title": "", "scientific_name": "", "tax_id": 9606, "collection date": "not provided", "geographic location (country and/or sea)": "not provided"}}],
             "files": [{"analysisAlias": "", "fileName": "", "fileSize": 1000, "md5": ""}]
@@ -44,7 +44,7 @@ class TestValidateMetadata(TestCase):
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
             json.dump(unclean_json, tmp)
             temp_path_unclean = tmp.name
-        format_metadata.format_experiment_type_lowercase(temp_path_unclean, temp_path_unclean_output)
+        format_metadata.format_experiment_type(temp_path_unclean, temp_path_unclean_output)
         with open(temp_path_unclean_output, 'r') as f:
             result_data = json.load(f)
         expected = unclean_json


### PR DESCRIPTION
Work in progress for review and feedback. This PR changes the experiment type in the EVA json file to be case insensitive.  
Changes made:
- format_metadata.py: changes experiment type to be case insensitive.
- validation.nf: nextflow pipeline edited to run format_metadata.py (work in progress)
- test_format_metadata.py: unit testing for format_metadata.py
Related to: [PR#24 ](https://github.com/EBIvariation/eva-sub-cli/pull/24#discussion_r1494618202)
