### PR TITLE
Add schema at the end of validation

### DIFF
--- a/eva_sub_cli/executables/xlsx2json.py
+++ b/eva_sub_cli/executables/xlsx2json.py
@@ -9,8 +9,6 @@ from ebi_eva_common_pyutils.logger import logging_config
 from openpyxl.reader.excel import load_workbook
 from openpyxl.workbook import Workbook
 
-from eva_sub_cli.utils import get_json_schema_link as _get_json_schema_link
-
 WORKSHEETS_KEY_NAME = 'worksheets'
 REQUIRED_HEADERS_KEY_NAME = 'required'
 OPTIONAL_HEADERS_KEY_NAME = 'optional'
@@ -259,8 +257,7 @@ class XlsxParser:
         # If the file could not be loaded at all, return without generating JSON.
         if not self.file_loaded:
             return
-        # Include which version of the EVA schema we are using
-        json_data = {'$schema': self.get_json_schema_link()}
+        json_data = {}
         for title in self.xlsx_conf[WORKSHEETS_KEY_NAME]:
             self.active_worksheet = title
             if title == PROJECT:
@@ -281,8 +278,6 @@ class XlsxParser:
         with open(output_json_file, 'w') as open_file:
             json.dump(json_data, open_file, cls=DateTimeEncoder)
 
-    def get_json_schema_link(self):
-        return _get_json_schema_link()
 
     def translate_header(self, title, header):
         if header in self.xlsx_conf[title].get(REQUIRED_HEADERS_KEY_NAME, {}):

--- a/eva_sub_cli/executables/xlsx2json.py
+++ b/eva_sub_cli/executables/xlsx2json.py
@@ -9,7 +9,7 @@ from ebi_eva_common_pyutils.logger import logging_config
 from openpyxl.reader.excel import load_workbook
 from openpyxl.workbook import Workbook
 
-from eva_sub_cli.orchestrator import get_sub_cli_version, get_sub_cli_github_tags
+from eva_sub_cli.utils import get_json_schema_link as _get_json_schema_link
 
 WORKSHEETS_KEY_NAME = 'worksheets'
 REQUIRED_HEADERS_KEY_NAME = 'required'
@@ -282,12 +282,7 @@ class XlsxParser:
             json.dump(json_data, open_file, cls=DateTimeEncoder)
 
     def get_json_schema_link(self):
-        sub_cli_version = get_sub_cli_version()
-        sub_cli_tags = get_sub_cli_github_tags()
-        if sub_cli_version in sub_cli_tags:
-            return f'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/refs/tags/v{sub_cli_version}/eva_sub_cli/etc/eva_schema.json'
-        else:
-            return 'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/main/eva_sub_cli/etc/eva_schema.json'
+        return _get_json_schema_link()
 
     def translate_header(self, title, header):
         if header in self.xlsx_conf[title].get(REQUIRED_HEADERS_KEY_NAME, {}):

--- a/eva_sub_cli/orchestrator.py
+++ b/eva_sub_cli/orchestrator.py
@@ -9,10 +9,7 @@ from ebi_eva_common_pyutils.config import WritableConfig
 from ebi_eva_common_pyutils.logger import logging_config
 from openpyxl.reader.excel import load_workbook
 from packaging import version
-from requests import HTTPError
-from retry import retry
 
-import eva_sub_cli
 from eva_sub_cli import MINIMUM_METADATA_XLSX_TEMPLATE_VERSION
 from eva_sub_cli import SUB_CLI_CONFIG_FILE, __version__
 from eva_sub_cli.exceptions import InvalidFileTypeError, MetadataTemplateVersionException, \
@@ -23,7 +20,7 @@ from eva_sub_cli.metadata import EvaMetadataJson
 from eva_sub_cli.submission_ws import SubmissionWSClient
 from eva_sub_cli.submit import StudySubmitter, SUB_CLI_CONFIG_KEY_SUBMISSION_ID, \
     SUB_CLI_CONFIG_KEY_SUBMISSION_UPLOAD_URL
-from eva_sub_cli.utils import get_project_title_from_ena
+from eva_sub_cli.utils import get_project_title_from_ena, get_metadata_xlsx_template_link
 from eva_sub_cli.validators.docker_validator import DockerValidator
 from eva_sub_cli.validators.native_validator import NativeValidator
 from eva_sub_cli.validators.validator import READY_FOR_SUBMISSION_TO_EVA, ALL_VALIDATION_TASKS
@@ -152,46 +149,6 @@ def get_project_and_vcf_fasta_mapping_from_metadata_json(metadata_json):
                                          os.path.abspath(assembly_report) if assembly_report else ''])
 
     return project_title, vcf_fasta_report_mapping
-
-
-def get_sub_cli_version():
-    if version.parse(eva_sub_cli.__version__).is_devrelease:
-        version_values = [int(v) for v in version.parse(eva_sub_cli.__version__).base_version.split('.')]
-        major = version_values[0]
-        minor = version_values[1] if len(version_values) > 1 else 0
-        patch = version_values[2] if len(version_values) > 2 else 0
-        if patch > 0:
-            patch -= 1
-        elif minor > 0:
-            minor -= 1
-            patch = 0
-        elif major > 0:
-            major -= 1
-            minor = 0
-            patch = 0
-        return f"{major}.{minor}.{patch}"
-    else:
-        return version.parse(eva_sub_cli.__version__).base_version
-
-
-@retry(exceptions=(HTTPError,), tries=3, delay=2, backoff=1.2, jitter=(1, 3))
-def get_sub_cli_github_tags():
-    url = f"https://api.github.com/repos/EBIvariation/eva-sub-cli/tags"
-    response = requests.get(url)
-    if response.status_code == 200:
-        tags = [tag["name"][1:] for tag in response.json()]
-        return tags
-    else:
-        return []
-
-
-def get_metadata_xlsx_template_link():
-    sub_cli_version = get_sub_cli_version()
-    sub_cli_tags = get_sub_cli_github_tags()
-    if sub_cli_version in sub_cli_tags:
-        return f'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/refs/tags/v{sub_cli_version}/eva_sub_cli/etc/EVA_Submission_template.xlsx'
-    else:
-        return 'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/main/eva_sub_cli/etc/EVA_Submission_template.xlsx'
 
 
 def verify_and_get_metadata_xlsx_version(metadata_xlsx, min_req_version):

--- a/eva_sub_cli/utils.py
+++ b/eva_sub_cli/utils.py
@@ -1,5 +1,10 @@
-from ebi_eva_common_pyutils.ena_utils import download_xml_from_ena
+import requests
+from packaging import version
 from requests import HTTPError
+from retry import retry
+
+import eva_sub_cli
+from ebi_eva_common_pyutils.ena_utils import download_xml_from_ena
 
 
 def get_project_title_from_ena(project_accession):
@@ -18,3 +23,50 @@ def get_project_title_from_ena(project_accession):
     return project_title
 
 
+def get_sub_cli_version():
+    if version.parse(eva_sub_cli.__version__).is_devrelease:
+        version_values = [int(v) for v in version.parse(eva_sub_cli.__version__).base_version.split('.')]
+        major = version_values[0]
+        minor = version_values[1] if len(version_values) > 1 else 0
+        patch = version_values[2] if len(version_values) > 2 else 0
+        if patch > 0:
+            patch -= 1
+        elif minor > 0:
+            minor -= 1
+            patch = 0
+        elif major > 0:
+            major -= 1
+            minor = 0
+            patch = 0
+        return f"{major}.{minor}.{patch}"
+    else:
+        return version.parse(eva_sub_cli.__version__).base_version
+
+
+@retry(exceptions=(HTTPError,), tries=3, delay=2, backoff=1.2, jitter=(1, 3))
+def get_sub_cli_github_tags():
+    url = f"https://api.github.com/repos/EBIvariation/eva-sub-cli/tags"
+    response = requests.get(url)
+    if response.status_code == 200:
+        tags = [tag["name"][1:] for tag in response.json()]
+        return tags
+    else:
+        return []
+
+
+def get_metadata_xlsx_template_link():
+    sub_cli_version = get_sub_cli_version()
+    sub_cli_tags = get_sub_cli_github_tags()
+    if sub_cli_version in sub_cli_tags:
+        return f'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/refs/tags/v{sub_cli_version}/eva_sub_cli/etc/EVA_Submission_template.xlsx'
+    else:
+        return 'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/main/eva_sub_cli/etc/EVA_Submission_template.xlsx'
+
+
+def get_json_schema_link():
+    sub_cli_version = get_sub_cli_version()
+    sub_cli_tags = get_sub_cli_github_tags()
+    if sub_cli_version in sub_cli_tags:
+        return f'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/refs/tags/v{sub_cli_version}/eva_sub_cli/etc/eva_schema.json'
+    else:
+        return 'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/main/eva_sub_cli/etc/eva_schema.json'

--- a/eva_sub_cli/validators/validator.py
+++ b/eva_sub_cli/validators/validator.py
@@ -605,9 +605,8 @@ class Validator(AppLogger):
     def _add_schema_to_metadata(self):
         if self.metadata_json_post_validation:
             metadata = EvaMetadataJson(self.metadata_json_post_validation)
-            if '$schema' not in metadata.content:
-                metadata.content['$schema'] = get_json_schema_link()
-                metadata.write(self.metadata_json_post_validation)
+            metadata.content['$schema'] = get_json_schema_link()
+            metadata.write(self.metadata_json_post_validation)
 
     def _update_metadata_with_evidence_type(self):
         if self.metadata_json_post_validation:

--- a/eva_sub_cli/validators/validator.py
+++ b/eva_sub_cli/validators/validator.py
@@ -14,6 +14,7 @@ from packaging import version
 
 import eva_sub_cli
 from eva_sub_cli import ETC_DIR, SUB_CLI_CONFIG_FILE, __version__
+from eva_sub_cli.utils import get_json_schema_link
 from eva_sub_cli.file_utils import resolve_single_file_path
 from eva_sub_cli.metadata import EvaMetadataJson
 from eva_sub_cli.report import generate_html_report, generate_text_report
@@ -448,6 +449,7 @@ class Validator(AppLogger):
             self._convert_biovalidator_validation_to_spreadsheet()
             self._write_spreadsheet_validation_results()
         self._collect_file_info_to_metadata()
+        self._add_schema_to_metadata()
 
     def _load_spreadsheet_conversion_errors(self):
         errors_file = resolve_single_file_path(os.path.join(self.output_dir, 'other_validations',
@@ -599,6 +601,13 @@ class Validator(AppLogger):
                 self.results[METADATA_CHECK]['json_errors'].extend(errors)
             else:
                 self.results[METADATA_CHECK]['json_errors'] = errors
+
+    def _add_schema_to_metadata(self):
+        if self.metadata_json_post_validation:
+            metadata = EvaMetadataJson(self.metadata_json_post_validation)
+            if '$schema' not in metadata.content:
+                metadata.content['$schema'] = get_json_schema_link()
+                metadata.write(self.metadata_json_post_validation)
 
     def _update_metadata_with_evidence_type(self):
         if self.metadata_json_post_validation:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -16,8 +16,8 @@ from eva_sub_cli.exceptions import InvalidFileTypeError, MetadataTemplateVersion
 from eva_sub_cli.file_utils import is_vcf_file
 from eva_sub_cli.metadata import EvaMetadataJson
 from eva_sub_cli.orchestrator import orchestrate_process, VALIDATE, SUBMIT, DOCKER, check_validation_required, \
-    verify_and_get_metadata_xlsx_version, get_metadata_xlsx_template_link, get_sub_cli_github_tags, \
-    remove_non_vcf_files_from_metadata, get_project_title_and_create_vcf_files_mapping
+    verify_and_get_metadata_xlsx_version, remove_non_vcf_files_from_metadata
+from eva_sub_cli.utils import get_metadata_xlsx_template_link, get_sub_cli_github_tags
 from eva_sub_cli.submit import SUB_CLI_CONFIG_KEY_SUBMISSION_ID, SUB_CLI_CONFIG_KEY_SUBMISSION_UPLOAD_URL
 from eva_sub_cli.validators.validator import READY_FOR_SUBMISSION_TO_EVA, ALL_VALIDATION_TASKS
 from tests.test_utils import touch
@@ -401,8 +401,8 @@ class TestOrchestrator(unittest.TestCase):
             assert get_sub_cli_github_tags() == []
 
     def test_get_metadata_xlsx_template_link(self):
-        with patch('eva_sub_cli.orchestrator.get_sub_cli_version') as sub_cli_version, \
-                patch('eva_sub_cli.orchestrator.get_sub_cli_github_tags') as sub_cli_tags:
+        with patch('eva_sub_cli.utils.get_sub_cli_version') as sub_cli_version, \
+                patch('eva_sub_cli.utils.get_sub_cli_github_tags') as sub_cli_tags:
             sub_cli_version.return_value = '1.1.6'
             sub_cli_tags.return_value = ['1.1.6']
             assert get_metadata_xlsx_template_link() == 'https://raw.githubusercontent.com/EBIvariation/eva-sub-cli/refs/tags/v1.1.6/eva_sub_cli/etc/EVA_Submission_template.xlsx'

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -16,7 +16,8 @@ from eva_sub_cli.exceptions import InvalidFileTypeError, MetadataTemplateVersion
 from eva_sub_cli.file_utils import is_vcf_file
 from eva_sub_cli.metadata import EvaMetadataJson
 from eva_sub_cli.orchestrator import orchestrate_process, VALIDATE, SUBMIT, DOCKER, check_validation_required, \
-    verify_and_get_metadata_xlsx_version, remove_non_vcf_files_from_metadata
+    verify_and_get_metadata_xlsx_version, remove_non_vcf_files_from_metadata, \
+    get_project_title_and_create_vcf_files_mapping
 from eva_sub_cli.utils import get_metadata_xlsx_template_link, get_sub_cli_github_tags
 from eva_sub_cli.submit import SUB_CLI_CONFIG_KEY_SUBMISSION_ID, SUB_CLI_CONFIG_KEY_SUBMISSION_UPLOAD_URL
 from eva_sub_cli.validators.validator import READY_FOR_SUBMISSION_TO_EVA, ALL_VALIDATION_TASKS

--- a/tests/test_xlsx2json.py
+++ b/tests/test_xlsx2json.py
@@ -59,8 +59,7 @@ class TestXlsReader(TestCase):
         with open(output_json) as open_file:
             json_data = json.load(open_file)
             # assert json file is created with expected data
-            assert sorted(json_data.keys()) == ['$schema', 'analysis', 'files', 'project', 'sample', 'submitterDetails']
-            json_data.pop('$schema', None)
+            assert sorted(json_data.keys()) == ['analysis', 'files', 'project', 'sample', 'submitterDetails']
             self.assertEqual(self.get_expected_json(), json_data)
 
         # assert json schema
@@ -87,8 +86,7 @@ class TestXlsReader(TestCase):
         with open(output_json) as open_file:
             json_data = json.load(open_file)
             # assert json file is created with expected data
-            assert sorted(json_data.keys()) == ['$schema', 'analysis', 'files', 'project', 'sample', 'submitterDetails']
-            json_data.pop('$schema', None)
+            assert sorted(json_data.keys()) == ['analysis', 'files', 'project', 'sample', 'submitterDetails']
             self.assertEqual(self.get_expected_json(), json_data)
 
         # assert json schema
@@ -113,8 +111,7 @@ class TestXlsReader(TestCase):
         with open(output_json) as open_file:
             json_data = json.load(open_file)
             # assert json file is created with expected data
-            assert sorted(json_data.keys()) == ['$schema', 'analysis', 'files', 'project', 'sample', 'submitterDetails']
-            json_data.pop('$schema', None)
+            assert sorted(json_data.keys()) == ['analysis', 'files', 'project', 'sample', 'submitterDetails']
             # get expected json and remove other fields apart from project accession for comparison
             expected_json = self.get_expected_json()
             expected_json['project'] = {'projectAccession': 'PRJEB12345'}
@@ -142,8 +139,7 @@ class TestXlsReader(TestCase):
         with open(output_json) as open_file:
             json_data = json.load(open_file)
             # assert json file is created with expected data
-            assert sorted(json_data.keys()) == ['$schema', 'analysis', 'files', 'project', 'sample', 'submitterDetails']
-            json_data.pop('$schema', None)
+            assert sorted(json_data.keys()) == ['analysis', 'files', 'project', 'sample', 'submitterDetails']
             expected_json = self.get_expected_json()
             expected_json['analysis'][0]['links'] = ['BioProject:PRJNA1435562']
             self.assertEqual(expected_json, json_data)
@@ -177,7 +173,7 @@ class TestXlsReader(TestCase):
         assert os.path.exists(output_json)
         with open(output_json) as open_file:
             json_data = json.load(open_file)
-            assert sorted(json_data.keys()) == ['$schema', 'analysis', 'files', 'project', 'sample', 'submitterDetails']
+            assert sorted(json_data.keys()) == ['analysis', 'files', 'project', 'sample', 'submitterDetails']
             # required field taxId is missing
             assert 'taxId' not in json_data['project']
             # novel sample is missing scientific name in characteristics and sample name


### PR DESCRIPTION
`$schema` was only added if the metadata was provided as a spreadsheet not when it was provided as a json.
Now it is added regardless of the source