### PR TITLE
Add support missing metadata validation files due to processing failure

### DIFF
--- a/eva_sub_cli/validators/validation_results_parsers.py
+++ b/eva_sub_cli/validators/validation_results_parsers.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 from ebi_eva_common_pyutils.logger import logging_config
@@ -124,8 +125,8 @@ def parse_biovalidator_validation_results(metadata_check_file):
         if l:
             return ansi_escape.sub('', l).strip()
 
-    if not metadata_check_file:
-        return
+    if not metadata_check_file or not os.path.isfile(metadata_check_file) is False:
+        return []
 
     errors = []
 

--- a/eva_sub_cli/validators/validation_results_parsers.py
+++ b/eva_sub_cli/validators/validation_results_parsers.py
@@ -125,7 +125,7 @@ def parse_biovalidator_validation_results(metadata_check_file):
         if l:
             return ansi_escape.sub('', l).strip()
 
-    if not metadata_check_file or not os.path.isfile(metadata_check_file) is False:
+    if not metadata_check_file or not os.path.isfile(metadata_check_file):
         return []
 
     errors = []

--- a/eva_sub_cli/validators/validator.py
+++ b/eva_sub_cli/validators/validator.py
@@ -465,7 +465,11 @@ class Validator(AppLogger):
         """
         metadata_check_file = resolve_single_file_path(os.path.join(self.output_dir, 'other_validations',
                                                                     'metadata_validation.txt'))
-        errors = parse_biovalidator_validation_results(metadata_check_file)
+        if metadata_check_file:
+            errors = parse_biovalidator_validation_results(metadata_check_file)
+        else:
+            errors = [{'property': '/',
+                       'description': 'Metadata JSON validation process failed to run or produce output'}]
         self.results[METADATA_CHECK].update({
             'json_report_path': metadata_check_file,
             'json_errors': errors
@@ -475,12 +479,13 @@ class Validator(AppLogger):
         errors_file = resolve_single_file_path(os.path.join(self.output_dir, 'other_validations',
                                                             'metadata_semantic_check.yml'))
         if not errors_file:
-            return
-        with open(errors_file) as open_yaml:
-            # errors is a list of dicts matching format of biovalidator errors
-            errors = yaml.safe_load(open_yaml)
-            # biovalidator error parsing always places a list here, even if no errors
-            self.results[METADATA_CHECK]['json_errors'] += errors
+            errors = [{'property': '/',
+                       'description': 'Metadata semantic check process failed to run or produce output'}]
+        else:
+            with open(errors_file) as open_yaml:
+                # errors is a list of dicts matching format of biovalidator errors
+                errors = yaml.safe_load(open_yaml) or []
+        self.results[METADATA_CHECK]['json_errors'] += errors
 
     def _convert_biovalidator_validation_to_spreadsheet(self):
         config_file = os.path.join(ETC_DIR, "spreadsheet2json_conf.yaml")
@@ -489,7 +494,7 @@ class Validator(AppLogger):
 
         if 'spreadsheet_errors' not in self.results[METADATA_CHECK]:
             self.results[METADATA_CHECK]['spreadsheet_errors'] = []
-        for error in self.results[METADATA_CHECK].get('json_errors', {}):
+        for error in self.results[METADATA_CHECK].get('json_errors') or {}:
             sheet_json, row_json, attribute_json = parse_metadata_property(error['property'])
             # There should only be one Project but adding the row back means it's easier for users to find
             if sheet_json == 'project' and row_json is None:

--- a/tests/test_validaton_results_parsers.py
+++ b/tests/test_validaton_results_parsers.py
@@ -2,7 +2,7 @@ import os.path
 from unittest import TestCase
 
 from eva_sub_cli.validators.validation_results_parsers import vcf_check_errors_is_critical, parse_assembly_check_log, \
-    parse_assembly_check_report
+    parse_assembly_check_report, parse_biovalidator_validation_results
 
 
 class TestValidationParsers(TestCase):
@@ -42,3 +42,7 @@ class TestValidationParsers(TestCase):
         assert nb_mismatch == 12
         assert error_list == ['Chromosome scaffold_chr1 is not present in FASTA file']
         assert nb_error == 1
+
+    def test_parse_biovalidator_validation_results_no_file(self):
+        assert parse_biovalidator_validation_results(None) == []
+        assert parse_biovalidator_validation_results('random_file_name') == []

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -576,6 +576,29 @@ class TestValidator(TestCase):
              'description': 'Column "Taxonomy ID" is not populated'}
         ]
 
+    def test_collect_biovalidator_validation_results_when_file_missing(self):
+        with TemporaryDirectory() as submission_dir:
+            validator = self.create_validator(submission_dir)
+            os.makedirs(os.path.join(validator.output_dir, 'other_validations'))
+            validator.results['metadata_check'] = {}
+            validator.collect_biovalidator_validation_results()
+            assert validator.results['metadata_check']['json_errors'] == [
+                {'property': '/',
+                 'description': 'Metadata JSON validation process failed to run or produce output'}
+            ]
+            assert validator.results['metadata_check']['json_report_path'] is None
+
+    def test_collect_semantic_metadata_results_when_file_missing(self):
+        with TemporaryDirectory() as submission_dir:
+            validator = self.create_validator(submission_dir)
+            os.makedirs(os.path.join(validator.output_dir, 'other_validations'))
+            validator.results['metadata_check'] = {'json_errors': []}
+            validator._collect_semantic_metadata_results()
+            assert validator.results['metadata_check']['json_errors'] == [
+                {'property': '/',
+                 'description': 'Metadata semantic check process failed to run or produce output'}
+            ]
+
     def test_collect_conversion_errors(self):
         self.validator.results['metadata_check'] = {}
         self.validator._load_spreadsheet_conversion_errors()


### PR DESCRIPTION
This PR might be useful but is only needed because strict nextflow parser (fixed in #171) prevented the correct execution the validation. 
More change would be needed to be able to create a report after a complete nextflow failure. 